### PR TITLE
Update chatlog-parser.js

### DIFF
--- a/js/chatlog-parser.js
+++ b/js/chatlog-parser.js
@@ -265,6 +265,13 @@ $(document).ready(function() {
         return line.replace(/\[\d{2}:\d{2}:\d{2}\] /g, "").trim();
     }
 
+    /** 
+    * Removes "CHAT LOG:" that is pre-embedded in every log file you download for every "/ame". 
+    */
+    function removeChatLog(line) {
+        return text.replace(/^CHAT LOG:.*$/gm, '');
+    }
+
     /**
      * Formats a line with filters applied
      * @param {string} line - The line to format


### PR DESCRIPTION
Every /ame in the log file has "CHAT LOG: " pre-embedded which makes the /ame to be considered as white text but in reality it should be the pinkish rp color " * ". I was running into the problem thought, I'd take time to make this small fix.

![image](https://github.com/user-attachments/assets/2fdfb3be-8e58-4b93-889c-c13e2aa915fa)
