### PR TITLE
Fix apostrophe entity parsing

### DIFF
--- a/js/chatlog-parser.js
+++ b/js/chatlog-parser.js
@@ -95,11 +95,16 @@ $(document).ready(function() {
         return text.replace(/(\.{2,3}-|-\.{2,3})/g, '—');
     }
 
+    function fixBrokenApostrophes(text) {
+        return text.replace(/&(amp;)?(?:apos|apost)[;:]/g, "'");
+    }
+
     function processOutput() {
         const chatText = $textarea.val();
         const chatLines = chatText.split("\n")
                                   .map(removeTimestamps)
-                                  .map(replaceDashes);
+                                  .map(replaceDashes)
+                                  .map(fixBrokenApostrophes);
 
         const fragment = document.createDocumentFragment();
 


### PR DESCRIPTION
## Summary
- normalize HTML apostrophe entities when processing chat logs

## Testing
- `eslint js/chatlog-parser.js` *(fails: no ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_685bd82f72b48330a6f1f9768566c3d8