### PR TITLE
Fix censorship line duplication

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -479,7 +479,7 @@ html::-webkit-scrollbar {
 }
 
 .pixelated {
-	filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='pixelate-filter'><feOffset dx='0' dy='0' result='box-blur'/><feFlood x='1' y='1' height='1' width='1'/><feComposite width='3' height='3'/><feTile result='tiles'/><feComposite in='box-blur' operator='in'/><feMorphology operator='dilate' radius='1'/></filter></svg>#pixelate-filter");
+        filter: blur(5px);
 }
 
 .hidden {

--- a/css/modern.css
+++ b/css/modern.css
@@ -315,7 +315,7 @@ html::-webkit-scrollbar {
 }
 
 .pixelated {
-  filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='pixelate-filter'><feOffset dx='0' dy='0' result='box-blur'/><feFlood x='1' y='1' height='1' width='1'/><feComposite width='3' height='3'/><feTile result='tiles'/><feComposite in='box-blur' operator='in'/><feMorphology operator='dilate' radius='1'/></filter></svg>#pixelate-filter");
+  filter: blur(5px);
 }
 
 .hidden {

--- a/js/chatlog-parser.js
+++ b/js/chatlog-parser.js
@@ -199,7 +199,9 @@ $(document).ready(function() {
 
     function applyUserCensorship(line) {
 
-        return line.replace(/÷(.*?)÷/g, (match, p1) => `<span class="${censorshipStyle} censored-content" data-original="${p1}">${p1}</span>`);
+        line = line.replace(/÷([^÷]*?)÷/g, (match, p1) => `<span class="${censorshipStyle} censored-content" data-original="${p1}">${p1}</span>`);
+
+        return line.replace(/÷/g, "");
     }
 
     function removeTimestamps(line) {


### PR DESCRIPTION
## Summary
- sanitize censorship markup to avoid stray characters
- use `blur()` for pixelation to improve browser compatibility

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c9419700c8330b9648b35e1bb4fc4