### PR TITLE
Add orange color for 'You took' lines

### DIFF
--- a/js/chatlog-parser.js
+++ b/js/chatlog-parser.js
@@ -631,6 +631,8 @@ $(document).ready(function() {
 
         if (lowerLine.startsWith("you placed")) return wrapSpan("orange", line);
 
+        if (lowerLine.startsWith("you took")) return wrapSpan("orange", line);
+
         if (lowerLine.includes("from the property")) return wrapSpan("death", line);
 
         if (lowerLine.startsWith("you dropped")) return wrapSpan("death", line);


### PR DESCRIPTION
## Summary
- color lines starting with `You took` in orange

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d92b7023c8330b7cb4d117eaec8ff