### PR TITLE
Update changelog for recent parser tweaks

### DIFF
--- a/js/changelog-data.js
+++ b/js/changelog-data.js
@@ -1,5 +1,24 @@
 const CHANGELOG_ENTRIES = [
     {
+        date: '2025-07-11',
+        changes: [
+            'Skipped kick/ban messages in chatlog parser to hide administrative notifications'
+        ]
+    },
+    {
+        date: '2025-07-09',
+        changes: [
+            'Refactored speech line handling and speaker color detection for greater accuracy',
+            'Specially formatted [!] lines and filtered certain system messages'
+        ]
+    },
+    {
+        date: '2025-07-08',
+        changes: [
+            'Added orange coloring for lines beginning with "You took"'
+        ]
+    },
+    {
         date: '2025-07-05',
         changes: [
             'Fixed SMS message bracket removal issue - now preserves brackets in message content like [LOCATION]'


### PR DESCRIPTION
## Summary
- record refactors and formatting improvements from July 9
- note orange coloring for "You took" lines
- include skip of kick/ban messages from July 11

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870ddaf60bc83308dfb388411ab01eb