### PR TITLE
Fix high DPI downloads

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -99,6 +99,7 @@ function downloadOutputImage() {
 
   const height = output.prop('scrollHeight') + 100;
   const width = output.width();
+  const scale = window.devicePixelRatio || 1;
   const originalPadding = output.css('padding-bottom');
 
   output.css('padding-bottom', '100px');
@@ -106,17 +107,17 @@ function downloadOutputImage() {
   // Configure dom-to-image with CORS handling
   const domtoimageOptions = window.CORSHandler ? 
     window.CORSHandler.getDomToImageOptions({
-      width: width,
-      height: height,
+      width: width * scale,
+      height: height * scale,
       style: {
-        transform: 'scale(1)',
+        transform: `scale(${scale})`,
         transformOrigin: "top left",
       }
     }) : {
-      width: width,
-      height: height,
+      width: width * scale,
+      height: height * scale,
       style: {
-        transform: 'scale(1)',
+        transform: `scale(${scale})`,
         transformOrigin: "top left",
       },
       filter: function(node) {


### PR DESCRIPTION
## Summary
- improve downloaded images on high-DPI screens by respecting `window.devicePixelRatio`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687adf164610833088cf79f4ab431203